### PR TITLE
Don't overwrite Halo group if already exists

### DIFF
--- a/autoload/halo.vim
+++ b/autoload/halo.vim
@@ -4,9 +4,11 @@ if !has('timers')
 endif
 
 " Configuration {{{1
-highlight Halo guifg=white guibg=#F92672 ctermfg=white ctermbg=197
-autocmd ColorScheme *
-      \ highlight Halo guifg=white guibg=#F92672 ctermfg=white ctermbg=197
+if !hlexists('Halo')
+  highlight Halo guifg=white guibg=#F92672 ctermfg=white ctermbg=197
+  autocmd ColorScheme *
+        \ highlight Halo guifg=white guibg=#F92672 ctermfg=white ctermbg=197
+endif
 
 let s:defaults = {
       \ 'hlgroup':   'Halo',


### PR DESCRIPTION
First of all, thanks for taking your time to make this plugin! I was looking exactly for that functionally on vim.

I added a Halo group on the colorscheme I use, I just prefer a different default, so I think it would be good if the plugin doesn't change it.
